### PR TITLE
Respect NO_WEB in CLI project, too

### DIFF
--- a/src/FastTrack-Cli.pro
+++ b/src/FastTrack-Cli.pro
@@ -1,4 +1,8 @@
 greaterThan(QT_MAJOR_VERSION, 5): QT += widgets webenginewidgets core gui network
+NO_WEB {
+        QT -= webenginewidgets
+        DEFINES += NO_WEB
+}
 
 TARGET = fasttrack-cli
 TEMPLATE = app


### PR DESCRIPTION
This PR simply copies the `NO_WEB` handling from `FastTrack.pro` to `FastTrack-Cli.pro`.

I needed this change to update the `fasttrack` package in Fedora Linux, where the Qt6 version of QtWebEngine is not available.